### PR TITLE
Always use physical PWD

### DIFF
--- a/pwd_info.fish
+++ b/pwd_info.fish
@@ -2,7 +2,7 @@ function pwd_info -a separator -d "Print easy-to-parse information the current w
     set -l home ~
     set -l git_root (command git rev-parse --show-toplevel ^ /dev/null)
 
-    echo "$PWD" | awk -v home="$home" -v git_root="$git_root" -v separator="$separator" '
+    pwd -P | awk -v home="$home" -v git_root="$git_root" -v separator="$separator" '
         function base(string) {
             sub(/^\/?.*\//, "", string)
             return string


### PR DESCRIPTION
Since https://github.com/fish-shell/fish-shell/commit/0f0bb1e10f0f9d749b3d4a48de3a9d86376a7825 `$PWD` doesn't resolve symlinks. This causes an issue as `git rev-parse --show-toplevel` returns the physical directory. This causes the third return value of `pwd_info` to contain the full logical path rather than the relative path in the git repo.

**Example**
Git repo in Physical directory `/Volumes/development/my_project`
Symlink at `~/dev/` links to `/Volumes/development/`

Current `pwd_info /` behaviour when in my_project folder as accessed via symlink
```
my_project
V/d
/h/m/d
```
Expected behaviour
```
my_project
V/d

```

The easiest fix I could come up with was to force `$PWD` to be the physical directory using the command instead of the environment variable.

The other option would be to make the whole function symlink aware which require using https://git-scm.com/docs/git-rev-parse#git-rev-parse---show-prefix but that seemed more complicated.

Let me know your thoughts