### PR TITLE
Use system `pwd` instead of builtin

### DIFF
--- a/pwd_info.fish
+++ b/pwd_info.fish
@@ -2,7 +2,7 @@ function pwd_info -a separator -d "Print easy-to-parse information the current w
     set -l home ~
     set -l git_root (command git rev-parse --show-toplevel ^ /dev/null)
 
-    pwd -P | awk -v home="$home" -v git_root="$git_root" -v separator="$separator" '
+    command pwd -P | awk -v home="$home" -v git_root="$git_root" -v separator="$separator" '
         function base(string) {
             sub(/^\/?.*\//, "", string)
             return string


### PR DESCRIPTION
The `pwd` fish shell builtin does not have the `-P` or `-L` options in version `2.7.1` (which seems to be the [last release before `3.0.0`](https://github.com/fish-shell/fish-shell/releases)). This PR uses the system's `pwd` so that this package works with `2.7.1` as well and doesn't depend on the fish shell version. Thanks.