### PR TITLE
More informative hidden directory info

### DIFF
--- a/pwd_info.fish
+++ b/pwd_info.fish
@@ -7,13 +7,20 @@ function pwd_info -a separator -d "Print easy-to-parse information the current w
             sub(/^\/?.*\//, "", string)
             return string
         }
-        function dirs(string, printLastName,   prefix, path) {
+        function dir_abbr(dir) {
+            abbr = dir_length == 0 ? dir : substr(dir, 1, dir_length ? dir_length : 1)
+            # Just "." can happen depending on the value of `dir_length`
+            # This is not very informative, so add an additional character
+            name = abbr == "." ? substr(dir, 1, 2) : abbr
+            return name
+        }
+        function dirs(string, printLastName, prefix, path) {
             len = split(string, parts, "/")
             for (i = 1; i < len; i++) {
-                name = dir_length == 0 ? parts[i] : substr(parts[i], 1, dir_length ? dir_length : 1)
-                if (parts[i] == "" || name == ".") {
+                if (parts[i] == "") {
                     continue
                 }
+                name = dir_abbr(parts[i])
                 path = path prefix name
                 prefix = separator
             }
@@ -30,8 +37,7 @@ function pwd_info -a separator -d "Print easy-to-parse information the current w
             if (git_root == "") {
                 printf("%s\n%s\n%s\n",
                     $0 == home || $0 == "/" ? "" : base($0),
-                    dirs(remove(home, $0)),
-                    "")
+                    dirs(remove(home, $0)), "")
             } else {
                 printf("%s\n%s\n%s\n",
                     base(git_root),


### PR DESCRIPTION
As I was testing out the [Mono](https://github.com/fishpkg/mono) prompt, I noticed that changing directories into hidden directories (`~/.config`) wasn't always being displayed like how I would have thought.

**example:**
If I cd into `~./config` the prompt would show `.config` - this is expected. ✅ 
If I then cd in `fish` (`~./config/fish/`) I would _expect_ it to show `.c/fish`, but instead it just shows `fish`.  ❓ 
Going into an additional directory shows `f/` correctly, but still no indication we're inside of the `.config` directory 🤷 

At first I thought "ah this prompt must have some more clever way of denoting you're in a hidden directory". The I started hacking around and found out that the issue I might be having was inside of this code.


<img width="215" alt="image" src="https://user-images.githubusercontent.com/20746446/95786903-144eb280-0c9e-11eb-89ef-8552dd5258d2.png">

I'm not really sure what the original intention of the code was (maybe it was "don't show `.` in `.config`" ? ), however, I feel the extra change here might be more consistent with how other `pwd` helpers (such as `prompt_pwd`) work. 

Usually Awk looks like alphabet soup to me, so I tried to keep with the style of the existing code. 🤞 

The psuedo for my changes is
```
Try to get just the first x characters of the directory name (x defaults to 1)
Is the first chracter just a "." ? If so, grab an additional character so it becomes ".Y" instead
return shortened directory name
```

This should work with various lengths of  `$fish_prompt_pwd_dir_length` as well - if that's set to `3` for instance, it shouldn't ever get to the `if only "."` logic

Again, I'm not sure what the original intent of this code is suppose to be, so if I've done something that's completely against the original vision, then it can just live in my fork and I'll be happy with that, but I thought that maybe others could have been scratching their heads over this. 

**After**
<img width="271" alt="image" src="https://user-images.githubusercontent.com/20746446/95786932-216ba180-0c9e-11eb-991d-949c944dba61.png">
